### PR TITLE
Fixed numpy value error on string

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -155,7 +155,7 @@ class SeriesCommon(Pane):
         return series
 
     def _single_datetime_format(self, arg):
-        if not pd.api.types.is_datetime64_any_dtype(arg):
+        if isinstance(arg, str) or not pd.api.types.is_datetime64_any_dtype(arg):
             arg = pd.to_datetime(arg)
         interval_seconds = self._interval.total_seconds()
         arg = interval_seconds * (arg.timestamp() // interval_seconds)


### PR DESCRIPTION
Hi this is an awesome library, thanks for sharing this! I hit an issue when trying to run example 2

```python
import pandas as pd
from time import sleep
from lightweight_charts import Chart

if __name__ == '__main__':

    chart = Chart()

    df1 = pd.read_csv('ohlcv.csv')
    df2 = pd.read_csv('next_ohlcv.csv')

    chart.set(df1)

    chart.show()

    last_close = df1.iloc[-1]
    
    for i, series in df2.iterrows():
        chart.update(series)

        if series['close'] > 20 and last_close < 20:
            chart.marker(text='The price crossed $20!')
            
        last_close = series['close']
        sleep(0.1)
```

![image](https://github.com/louisnw01/lightweight-charts-python/assets/31859220/e007a097-4cd8-49f8-83b7-4e473147c841)

This is when `chart.update(series)` is called in the above example, then in a method `_single_datetime_format` is where I see the issue.

I think `pd.api.types.is_datetime64_any_dtype` is expecting an array like data type but doesnt like strings? (which I thought it would). Anyways, this was my work around. Are you able to repro this? Or am I the only one hitting this issue?

Here is my environment
```
altair==5.1.1
attrs==23.1.0
blinker==1.6.2
bottle==0.12.25
cachetools==5.3.1
certifi==2023.7.22
cffi==1.15.1
charset-normalizer==3.2.0
click==8.1.7
clr-loader==0.2.6
colorama==0.4.6
gitdb==4.0.10
GitPython==3.1.33
idna==3.4
importlib-metadata==6.8.0
Jinja2==3.1.2
jsonschema==4.19.0
jsonschema-specifications==2023.7.1
lightweight-charts==1.0.17.1       
markdown-it-py==3.0.0
MarkupSafe==2.1.3
mdurl==0.1.2
numpy==1.25.2
packaging==23.1
pandas==2.1.0
Pillow==9.5.0
protobuf==4.24.2
proxy-tools==0.1.0
pyarrow==13.0.0
pycparser==2.21
pydeck==0.8.0
Pygments==2.16.1
Pympler==1.0.1
python-dateutil==2.8.2
pythonnet==3.0.2
pytz==2023.3
pytz-deprecation-shim==0.1.0.post0
pywebview==4.3.2
referencing==0.30.2
requests==2.31.0
rich==13.5.2
rpds-py==0.10.0
six==1.16.0
smmap==5.0.0
streamlit==1.26.0
tenacity==8.2.3
toml==0.10.2
toolz==0.12.0
tornado==6.3.3
typing_extensions==4.7.1
tzdata==2023.3
tzlocal==4.3.1
urllib3==2.0.4
validators==0.21.2
watchdog==3.0.0
zipp==3.16.2
```

Which I got by doing
```shell
pip install lightweight-charts
pip install streamlit
```