### PR TITLE
Made modifier key optional and adding support for more than just single alphnumeric keycodes

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -856,17 +856,17 @@ class AbstractChart(Candlestick, Pane):
 
         for key in keys:
             # when there is no modifier key use the key value
-            key_event_condition = f"event.key === '{key}'"
+            condition = f"event.key === '{key}'"
             # if there is a modifier key
             if modifier_key:
                 # use the key code instead
                 key_code = 'Key' + key.upper() if isinstance(key, str) else 'Digit' + str(key)
                 # change the condition to also require the modifier
-                key_event_condition = f"event.{modifier_key}Key && event.code === '{key_code}'"
+                condition = f"event.{modifier_key}Key && event.code === '{key_code}'"
 
             self.run_script(f'''
             {self.id}.commandFunctions.unshift((event) => {{
-                if ({key_event_condition}) {{
+                if ({condition}) {{
                     event.preventDefault()
                     window.callbackFunction(`{modifier_key, keys}_~_{key}`)
                     return true

--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -856,7 +856,7 @@ class AbstractChart(Candlestick, Pane):
 
         for key in keys:
             # when there is no modifier key use the key value
-            condition = f"event.key === '{key}'"
+            condition = f"event.key.toLowerCase() === '{str(key).lower()}'"
             # if there is a modifier key
             if modifier_key:
                 # use the key code instead

--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 from base64 import b64decode
 from datetime import datetime
-from typing import Union, Literal, List, Optional
+from typing import Union, Literal, List
 import pandas as pd
 
 from .table import Table
@@ -849,31 +849,24 @@ class AbstractChart(Candlestick, Pane):
     def spinner(self, visible):
         self.run_script(f"{self.id}.spinner.style.display = '{'block' if visible else 'none'}'")
 
-    def hotkey(
-        self,
-        keys: Union[str, tuple, int],
-        func: callable,
-        modifier_key: Optional[Literal['ctrl', 'alt', 'shift', 'meta']] = None
-    ):
+    def hotkey(self, modifier_key: Literal['ctrl', 'alt', 'shift', 'meta', None],
+               keys: Union[str, tuple, int], func: callable):
         if not isinstance(keys, tuple):
             keys = (keys,)
 
         for key in keys:
-            # default to taking the key code as is
-            key_code = key
-            # if the key code is only one character or digit, build the correct key code
-            if len(str(key)) == 1:
-                key_code = 'Key' + key.upper() if isinstance(key, str) else 'Digit' + str(key)
-
-            # default to no modifier key
-            modifier_key_js = ''
-            # if there is a modifier key, create the js
+            # when there is no modifier key use the key value
+            key_event_condition = f"event.key === '{key}'"
+            # if there is a modifier key
             if modifier_key:
-                modifier_key_js = f"event.{modifier_key}Key && "
+                # use the key code instead
+                key_code = 'Key' + key.upper() if isinstance(key, str) else 'Digit' + str(key)
+                # change the condition to also require the modifier
+                key_event_condition = f"event.{modifier_key}Key && event.code === '{key_code}'"
 
             self.run_script(f'''
             {self.id}.commandFunctions.unshift((event) => {{
-                if ({modifier_key_js}event.code === '{key_code}') {{
+                if ({key_event_condition}) {{
                     event.preventDefault()
                     window.callbackFunction(`{modifier_key, keys}_~_{key}`)
                     return true


### PR DESCRIPTION
Following up on https://github.com/louisnw01/lightweight-charts-python/issues/113

Here is my proposed fix. I had to move the order of the arguments. Let me know your thoughts. If you are cool with the changes Ill add the updates to the documentation in this PR

## Usage
```python
chart.hotkey('Space', pause_event)
chart.hotkey('ArrowRight', move_forward_event, modifier_key='shift')
chart.hotkey((1, 2, 3), print_key, modifier_key='shift')
```

## Changes
* made modifier key optional
* handle multi character key names