### PR TITLE
Update abstract.py: Set default dtype for Series instantiation

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -659,7 +659,7 @@ class Candlestick(SeriesCommon):
                 f'Trying to update tick of time "{pd.to_datetime(series["time"])}", '
                 f'which occurs before the last bar time of '
                 f'"{pd.to_datetime(self._last_bar["time"])}".')
-        bar = pd.Series()
+        bar = pd.Series(dtype='float64')
         if series['time'] == self._last_bar['time']:
             bar = self._last_bar
             bar['high'] = max(self._last_bar['high'], series['price'])


### PR DESCRIPTION
As of  issue #291 

We want to instantiate pandas.Series with a default dtype to get rid of the warning:

`FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.`

