### PR TITLE
OHLC legend precision matches the precision of the rest of the chart

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -388,6 +388,7 @@ class SeriesCommon(Pane):
         """
         min_move = 1 / (10**precision)
         self.run_script(f'''
+        {self.id}.precision = {precision}
         {self.id}.series.applyOptions({{
             priceFormat: {{precision: {precision}, minMove: {min_move}}}
         }})''')


### PR DESCRIPTION
In the commit for the 1.0.16 release (https://github.com/louisnw01/lightweight-charts-python/commit/34ce3f7199b894e53b9cb07fc78adfb728eb2edf), the `precision` method of the `Chart` object was modifed such that the OHLC legend overlay showed prices with the same number of decimal places the user specified in `precision`.

This functionality regressed with the release of 2.0. Comparing the 1.0.x and 2.x `precision` methods, I noticed that this line was removed, which is part of the script passed to `run_script`:

```
{self.id}.precision = {precision}
```

This PR simply adds this line back to the script in the `precision` method. I used the styling example to test. Running it without calling `precision` uses the default 2 decimal places:

![Screenshot from 2024-12-19 18-53-25](https://github.com/user-attachments/assets/29abe393-7ac0-4f5b-8fda-1090c76660fc)

Adding
```
chart.precision(4)
```

![Screenshot from 2024-12-19 18-53-49](https://github.com/user-attachments/assets/2adc361c-86bb-4854-952d-40a8173828c1)
