### PR TITLE
Fix typo in abstract_chart.md: Update parameter name in trend_line()

### DIFF
--- a/docs/source/reference/abstract_chart.md
+++ b/docs/source/reference/abstract_chart.md
@@ -89,7 +89,7 @@ ___
 
 
 
-```{py:method} trend_line(start_time: str | datetime, start_value: NUM, end_time: str | datetime, end_value: NUM, color: COLOR, width: int, style: LINE_STYLE, round: bool) -> Line
+```{py:method} trend_line(start_time: str | datetime, start_value: NUM, end_time: str | datetime, end_value: NUM, line_color: COLOR, width: int, style: LINE_STYLE, round: bool) -> Line
 
 Creates a trend line, drawn from the first point (`start_time`, `start_value`) to the last point (`end_time`, `end_value`).
 


### PR DESCRIPTION
Corrected the parameter name from "color" to "line_color" in the trend_line() function documentation