### PR TITLE
fixing JupyterChart to be able to display non-overlay indicators

### DIFF
--- a/lightweight_charts/widgets.py
+++ b/lightweight_charts/widgets.py
@@ -177,7 +177,7 @@ class JupyterChart(StaticLWC):
             document.getElementById('container').style.width = '{self.width}px'
             document.getElementById('container').style.height = '100%'
             ''')
-        self.run_script(f'{self.id}.chart.resize({width}, {height})')
+        self.run_script(f'{self.id}.chart.resize({width * inner_width}, {height * inner_height})')
 
     def _load(self):
         if HTML is None:


### PR DESCRIPTION
Without this change JupyterChart doesn't display non-overlay indicators.
Not sure if this is the right way to fix this, at least it works for me.
Removing this line also seems to to fix the issue.