### PR TITLE
chore: Comment out the print output in the Drawing.update() method.

### DIFF
--- a/lightweight_charts/drawings.py
+++ b/lightweight_charts/drawings.py
@@ -30,7 +30,7 @@ class Drawing(Pane):
         for i in range(0, len(points), 2):
             formatted_points.append(make_js_point(self.chart, points[i], points[i + 1]))
         self.run_script(f'{self.id}.updatePoints({", ".join(formatted_points)})')
-        print(f'{self.id}.updatePoints({", ".join(formatted_points)})')
+        # print(f'{self.id}.updatePoints({", ".join(formatted_points)})')
 
     def delete(self):
         """


### PR DESCRIPTION
Frequent use of print() in Drawing.update() reduces performance.