### PR TITLE
Fix datetime to int64 Unix timestamp conversion, handling ns/us/ms units

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -202,10 +202,9 @@ class SeriesCommon(Pane):
         if not pd.api.types.is_datetime64_any_dtype(df['time']):
             df['time'] = pd.to_datetime(df['time'])
 
-        unit = str(df['time'].dtype).split('[')[-1][:-1]  # ns, us, ms, s
-        divisor = {'ns': 10**9, 'us': 10**6, 'ms': 10**3, 's': 1}[unit]
+        df['time'] = pd.to_datetime(df['time']).dt.tz_localize(None).astype('datetime64[ns]')
 
-        df['time'] = df['time'].astype('int64') // divisor
+        df['time'] = df['time'].astype('int64') // 10**9
         return df
 
     def _series_datetime_format(self, series: pd.Series, exclude_lowercase=None):

--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -198,9 +198,14 @@ class SeriesCommon(Pane):
         df = df.copy()
         df.columns = self._format_labels(df, df.columns, df.index, exclude_lowercase)
         self._set_interval(df)
+
         if not pd.api.types.is_datetime64_any_dtype(df['time']):
             df['time'] = pd.to_datetime(df['time'])
-        df['time'] = df['time'].astype('int64') // 10 ** 9
+
+        unit = str(df['time'].dtype).split('[')[-1][:-1]  # ns, us, ms, s
+        divisor = {'ns': 10**9, 'us': 10**6, 'ms': 10**3, 's': 1}[unit]
+
+        df['time'] = df['time'].astype('int64') // divisor
         return df
 
     def _series_datetime_format(self, series: pd.Series, exclude_lowercase=None):

--- a/lightweight_charts/widgets.py
+++ b/lightweight_charts/widgets.py
@@ -164,7 +164,7 @@ class StreamlitChart(StaticLWC):
 
 
 class JupyterChart(StaticLWC):
-    def __init__(self, width: int = 800, height=350, inner_width=1, inner_height=1, scale_candles_only: bool = False, toolbox: bool = False):
+    def __init__(self, width: int = 800, height=350, inner_width: float=1.0, inner_height: float=1.0, scale_candles_only: bool = False, toolbox: bool = False):
         super().__init__(width, height, inner_width, inner_height, scale_candles_only, toolbox, False)
 
         self.run_script(f'''
@@ -177,7 +177,7 @@ class JupyterChart(StaticLWC):
             document.getElementById('container').style.width = '{self.width}px'
             document.getElementById('container').style.height = '100%'
             ''')
-        self.run_script(f'{self.id}.chart.resize({width}, {height})')
+        self.run_script(f'{self.id}.chart.resize({width * inner_width}, {height * inner_height})')
 
     def _load(self):
         if HTML is None:


### PR DESCRIPTION
The function _df_datetime_format converts the 'time' column to seconds ([s]) using int64, but it does not consider that the source datetime64 column may have different precisions (ns, us, ms). The divisor should be selected based on the original column's datetime precision to ensure correct conversion.